### PR TITLE
HOTFIX: Use version 1 of orders-application-id secret as version 2 is destroyed

### DIFF
--- a/src/main/java/com/adkhub/orders/service/OrderService.java
+++ b/src/main/java/com/adkhub/orders/service/OrderService.java
@@ -72,7 +72,7 @@ public class OrderService {
     }
 
     private String getApplicationId() {
-        return gcpSecretManagerService.getSecret(projectId, secretId, "latest");
+        return gcpSecretManagerService.getSecret(projectId, secretId, "1");
     }
 
     public String generateShippingID(UUID orderID) {


### PR DESCRIPTION
The service was failing to confirm orders because it was trying to access a destroyed secret version. This commit changes the code to use version 1 of the secret.