### PR TITLE
HOTFIX: OS-1212 - Fix shipping ID generation log message

### DIFF
--- a/src/main/java/com/adkhub/orders/service/OrderService.java
+++ b/src/main/java/com/adkhub/orders/service/OrderService.java
@@ -77,7 +77,7 @@ public class OrderService {
 
     public String generateShippingID(UUID orderID) {
         String url = shippingServiceUrl + "/generate-shipping-id?orderId=" + orderID;
-        log.info("Requesting shipping ID from {} for order ID {}", url, orderID);
+        log.info("Requesting shipping ID from shipping service for order ID {}", orderID);
         try {
             HttpHeaders headers = new HttpHeaders();
             headers.set("application-id", getApplicationId());


### PR DESCRIPTION
Addresses the issue where the log message for shipping ID generation was not clear, by updating it to be more descriptive.