### PR TITLE
HOTFIX: Removed separate getApplicationId method and used direct secret access

### DIFF
--- a/src/main/java/com/adkhub/orders/service/OrderService.java
+++ b/src/main/java/com/adkhub/orders/service/OrderService.java
@@ -43,7 +43,7 @@ public class OrderService {
                         .description(description)
                         .confirmed(false)
                         .createdAt(LocalDateTime.now())
-                        .build()
+                .build()
         );
     }
 
@@ -71,16 +71,12 @@ public class OrderService {
         return orderOpt;
     }
 
-    private String getApplicationId() {
-        return gcpSecretManagerService.getSecret(projectId, secretId, "latest");
-    }
-
     public String generateShippingID(UUID orderID) {
         String url = shippingServiceUrl + "/generate-shipping-id?orderId=" + orderID;
         log.info("Requesting shipping ID from {} for order ID {}", url, orderID);
         try {
             HttpHeaders headers = new HttpHeaders();
-            headers.set("application-id", getApplicationId());
+            headers.set("application-id", gcpSecretManagerService.getSecret(projectId, secretId, "latest"));
             HttpEntity<String> entity = new HttpEntity<>(headers);
             ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
             String shippingIdStr = response.getBody();


### PR DESCRIPTION
Removed the separate getApplicationId() method and replaced its usage with direct access to the GCP Secret Manager Service to fetch the application ID. This fixes an issue where the application ID was not being retrieved correctly, leading to errors in shipping ID generation.