### PR TITLE
HOTFIX: Handle null or empty shipping ID

### DIFF
--- a/src/main/java/com/adkhub/orders/service/OrderService.java
+++ b/src/main/java/com/adkhub/orders/service/OrderService.java
@@ -84,6 +84,10 @@ public class OrderService {
             HttpEntity<String> entity = new HttpEntity<>(headers);
             ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
             String shippingIdStr = response.getBody();
+            if (shippingIdStr == null || shippingIdStr.trim().isEmpty()) {
+                log.error("Received null or empty shipping ID for order {}.", orderID);
+                return null;
+            }
             log.info("Received shipping ID response: {}", shippingIdStr);
             return shippingIdStr;
         } catch (Exception e) {


### PR DESCRIPTION
Fixes an issue where the shipping ID returned from the external service could be null or empty, leading to a RuntimeException during order confirmation.