### PR TITLE
HOTFIX: Fix Failed to Generate Shipping ID Error

### DIFF
--- a/src/main/java/com/adkhub/orders/service/OrderService.java
+++ b/src/main/java/com/adkhub/orders/service/OrderService.java
@@ -72,7 +72,7 @@ public class OrderService {
     }
 
     private String getApplicationId() {
-        return gcpSecretManagerService.getSecret(projectId, secretId, "latest");
+        return gcpSecretManagerService.getSecret(projectId, secretId, "1");
     }
 
     public String generateShippingID(UUID orderID) {


### PR DESCRIPTION
Addresses the critical error 'Failed to generate shipping ID. Order confirmation aborted.' by reverting the secret version used in getApplicationId() from 'latest' to '1' in OrderService.java. This is a hotfix for a production issue.