### PR TITLE
HOTFIX: Failed to generate shipping ID. Order confirmation aborted.

### DIFF
--- a/src/main/java/com/adkhub/orders/service/OrderService.java
+++ b/src/main/java/com/adkhub/orders/service/OrderService.java
@@ -72,7 +72,7 @@ public class OrderService {
     }
 
     private String getApplicationId() {
-        return gcpSecretManagerService.getSecret(projectId, secretId, "latest");
+        return gcpSecretManagerService.getSecret(projectId, secretId, "8");
     }
 
     public String generateShippingID(UUID orderID) {


### PR DESCRIPTION
Reverted orders-application-id secret version to a previous stable version (8) to fix the 'Failed to generate shipping ID. Order confirmation aborted.' error.