### PR TITLE
HOTFIX: Fix shipping ID generation error

### DIFF
--- a/src/main/java/com/adkhub/orders/service/OrderService.java
+++ b/src/main/java/com/adkhub/orders/service/OrderService.java
@@ -72,7 +72,7 @@ public class OrderService {
     }
 
     private String getApplicationId() {
-        return gcpSecretManagerService.getSecret(projectId, secretId, "latest");
+        return gcpSecretManagerService.getSecret(projectId, secretId, "7");
     }
 
     public String generateShippingID(UUID orderID) {


### PR DESCRIPTION
Reverted 'orders-application-id' secret version to '7' to resolve 'Failed to generate shipping ID' error in OrderService.java.